### PR TITLE
Allow split to work with globbing expressions

### DIFF
--- a/shlex.go
+++ b/shlex.go
@@ -60,7 +60,7 @@ func (a *Token) Equal(b *Token) bool {
 }
 
 const (
-	RUNE_CHAR              string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-,/@$*()+=><:;&^%~|"
+	RUNE_CHAR              string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-,/@$*()+=><:;&^%~|!?[]"
 	RUNE_SPACE             string = " \t\r\n"
 	RUNE_ESCAPING_QUOTE    string = "\""
 	RUNE_NONESCAPING_QUOTE string = "'"

--- a/shlex_test.go
+++ b/shlex_test.go
@@ -126,6 +126,24 @@ func TestSplitEscapingQuotes(t *testing.T) {
 	}
 }
 
+func TestGlobbingExpressions(t *testing.T) {
+	testInput := "onefile *file one?ile onefil[de]"
+	expectedOutput := []string{"onefile", "*file", "one?ile", "onefil[de]"}
+	foundOutput, err := Split(testInput)
+	if err != nil {
+		t.Error("Split returned error", err)
+	}
+	if len(expectedOutput) != len(foundOutput) {
+		t.Error("Split expected:", len(expectedOutput), "results. Found:", len(foundOutput), "results")
+	}
+	for i := range foundOutput {
+		if foundOutput[i] != expectedOutput[i] {
+			t.Error("Item:", i, "(", foundOutput[i], ") differs from the expected value:", expectedOutput[i])
+		}
+	}
+
+}
+
 func TestSplitNonEscapingQuotes(t *testing.T) {
 	testInput := "one 'two three' four"
 	expectedOutput := []string{"one", "two three", "four"}


### PR DESCRIPTION
Current Split implementation breaks when globs are included, like "file?ame" or "[a-f]ilename"

Add characters needed to support globs
