### PR TITLE
Allow arbitrary chars in comments and quoted strings

### DIFF
--- a/shlex.go
+++ b/shlex.go
@@ -60,7 +60,7 @@ func (a *Token) Equal(b *Token) bool {
 }
 
 const (
-	RUNE_CHAR              string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-,/@$*()+=><:;&^%~|!?[]"
+	RUNE_CHAR              string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-,/@$*()+=><:;&^%~|!?[]{}"
 	RUNE_SPACE             string = " \t\r\n"
 	RUNE_ESCAPING_QUOTE    string = "\""
 	RUNE_NONESCAPING_QUOTE string = "'"
@@ -347,7 +347,7 @@ SCAN:
 						err = errors.New("EOF found when expecting closing quote.")
 						break SCAN
 					}
-				case RUNETOKEN_CHAR, RUNETOKEN_SPACE, RUNETOKEN_NONESCAPING_QUOTE, RUNETOKEN_COMMENT:
+				case RUNETOKEN_CHAR, RUNETOKEN_UNKNOWN, RUNETOKEN_SPACE, RUNETOKEN_NONESCAPING_QUOTE, RUNETOKEN_COMMENT:
 					{
 						value = append(value, nextRune)
 					}
@@ -373,7 +373,7 @@ SCAN:
 						err = errors.New("EOF found when expecting closing quote.")
 						break SCAN
 					}
-				case RUNETOKEN_CHAR, RUNETOKEN_SPACE, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT:
+				case RUNETOKEN_CHAR, RUNETOKEN_UNKNOWN, RUNETOKEN_SPACE, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT:
 					{
 						value = append(value, nextRune)
 					}
@@ -394,7 +394,7 @@ SCAN:
 					{
 						break SCAN
 					}
-				case RUNETOKEN_CHAR, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT, RUNETOKEN_NONESCAPING_QUOTE:
+				case RUNETOKEN_CHAR, RUNETOKEN_UNKNOWN, RUNETOKEN_ESCAPING_QUOTE, RUNETOKEN_ESCAPE, RUNETOKEN_COMMENT, RUNETOKEN_NONESCAPING_QUOTE:
 					{
 						value = append(value, nextRune)
 					}

--- a/shlex_test.go
+++ b/shlex_test.go
@@ -110,8 +110,8 @@ func TestSplitSimple(t *testing.T) {
 }
 
 func TestSplitEscapingQuotes(t *testing.T) {
-	testInput := "one \"two three\" four"
-	expectedOutput := []string{"one", "two three", "four"}
+	testInput := "one \"два ${three}\" four"
+	expectedOutput := []string{"one", "два ${three}", "four"}
 	foundOutput, err := Split(testInput)
 	if err != nil {
 		t.Error("Split returned error:", err)
@@ -145,8 +145,8 @@ func TestGlobbingExpressions(t *testing.T) {
 }
 
 func TestSplitNonEscapingQuotes(t *testing.T) {
-	testInput := "one 'two three' four"
-	expectedOutput := []string{"one", "two three", "four"}
+	testInput := "one 'два ${three}' four"
+	expectedOutput := []string{"one", "два ${three}", "four"}
 	foundOutput, err := Split(testInput)
 	if err != nil {
 		t.Error("Split returned error:", err)


### PR DESCRIPTION
Allow arbitrary chars in comments and quoted strings

Allow arbitrary characters in comments quoted strings (escaped and non-escaped).
Also, recignize curly braces `{}` as chars.
